### PR TITLE
fix bug with skill swapping

### DIFF
--- a/SimpleActionSets.lua
+++ b/SimpleActionSets.lua
@@ -701,7 +701,7 @@ function SASActionButton_OnClick(button)
 			-- Cursor fake drag is holding an action
 			SASDebug("SASActionButton_OnClick getting fake drag action " .. SAS_ParseActionInfo(SASFakeDragFrame.Action, 1));
 			if (SAS_Temp[bar] and SAS_Temp[bar][id]) then
-				LocalSavedAction = SAS_CopyTable(SAS_Temp[bar][id]);
+				LocalSavedAction = SAS_Temp[bar][id];
 			end
 			SAS_Temp[bar][id] = SASFakeDrag_Drop(1)
 			SASActions_UpdateAction(bar, id);


### PR DESCRIPTION
I found this bug while setting up my skill bars using the addon. I tried dragging and dropping a skill on top of another, and this resulted in an error:

ERROR: ...terface\AddOns\SimpleActionSets\SimpleActionSets.lua:2042: attempt to call a string value

I believe this fix should do the trick, but if I've broken something else let me know and I'll try to find a better fix.