### PR TITLE
Add key binding option

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,0 +1,32 @@
+<Bindings>
+    <Binding name="SAS_SET1" header="SAS_TITLE">
+        SAS_SwapSet(SAS_GetSetByName(1));
+    </Binding>
+    <Binding name="SAS_SET2">
+        SAS_SwapSet(SAS_GetSetByName(2));
+    </Binding>
+    <Binding name="SAS_SET3">
+        SAS_SwapSet(SAS_GetSetByName(3));
+    </Binding>
+    <Binding name="SAS_SET4">
+        SAS_SwapSet(SAS_GetSetByName(4));
+    </Binding>
+    <Binding name="SAS_SET5">
+        SAS_SwapSet(SAS_GetSetByName(5));
+    </Binding>
+    <Binding name="SAS_SET6">
+        SAS_SwapSet(SAS_GetSetByName(6));
+    </Binding>
+    <Binding name="SAS_SET7">
+        SAS_SwapSet(SAS_GetSetByName(7));
+    </Binding>
+    <Binding name="SAS_SET8">
+        SAS_SwapSet(SAS_GetSetByName(8));
+    </Binding>
+    <Binding name="SAS_SET9">
+        SAS_SwapSet(SAS_GetSetByName(9));
+    </Binding>
+    <Binding name="SAS_SET10">
+        SAS_SwapSet(SAS_GetSetByName(10));
+    </Binding>
+</Bindings>

--- a/SimpleActionSets.lua
+++ b/SimpleActionSets.lua
@@ -2264,6 +2264,20 @@ function SAS_UpgradeSets()
 	end
 end
 
+------------------------------
+--- Key Bindings functions ---
+------------------------------
+function SAS_GetSetByName(index)
+    if (not SAS_Saved or not SAS_Saved[PlrName] or not SAS_Saved[PlrName]["s"]) then
+        return nil;
+    end
+    local list = {};
+    for k, v in SAS_Saved[PlrName]["s"] do
+        tinsert(list, k);
+    end
+    table.sort(list);
+    return list[index];
+end
 
 -- Unused code
 

--- a/localization.lua
+++ b/localization.lua
@@ -92,3 +92,20 @@ SAS_TITAN_ID = "SAS";
 SAS_TITAN_LABEL = "Current Set: ";
 SAS_TITAN_NA = "n/a";
 SAS_TITAN_HINT = "Hint: Left-click to open sets frame."
+
+
+----------------------
+-- Key Binding text --
+----------------------
+BINDING_HEADER_SAS_TITLE = "Simple Action Sets";
+
+BINDING_NAME_SAS_SET1 = "Simple Action Set 1";
+BINDING_NAME_SAS_SET2 = "Simple Action Set 2";
+BINDING_NAME_SAS_SET3 = "Simple Action Set 3";
+BINDING_NAME_SAS_SET4 = "Simple Action Set 4";
+BINDING_NAME_SAS_SET5 = "Simple Action Set 5";
+BINDING_NAME_SAS_SET6 = "Simple Action Set 6";
+BINDING_NAME_SAS_SET7 = "Simple Action Set 7";
+BINDING_NAME_SAS_SET8 = "Simple Action Set 8";
+BINDING_NAME_SAS_SET9 = "Simple Action Set 9";
+BINDING_NAME_SAS_SET10 = "Simple Action Set 10";


### PR DESCRIPTION
**!!!Not tested yet with the Brain washing device, though it shouldn't interfere with it!!!**

Some sets may not be related a spec and having them bound to a key can be useful. Also, this can be used for characters without the brainwashing device.

Added a Binding.xml file with 10 sets to be mapped. The sets are determined by list order.

Added a function to the SimpleActionSets.lua to list the current saved sets and assign them an index number. This is to be called by the binding file.
The function is added toward the bottom, above the unused code (from line 2267). If it needs to be moved elsewhere, feel free to do/request so.

Added strings to localization.lua file for the binding frame.

How it looks like:
<img width="540" height="246" alt="image" src="https://github.com/user-attachments/assets/87900be4-bb43-4d3d-b13a-5e9845917fd0" />
